### PR TITLE
Add EF Core Relationships code samples

### DIFF
--- a/modules/02-database-ef-core/README.md
+++ b/modules/02-database-ef-core/README.md
@@ -1,0 +1,23 @@
+# Module 02: Database Management with Entity Framework Core
+
+Learn to implement efficient data access with Entity Framework Core. From basic CRUD operations to advanced concepts like entity relationships, concurrency control, and optimized query strategies.
+
+## Lessons
+
+| Lesson | Description |
+|--------|-------------|
+| [EF Core Relationships](./efcore-relationships/) | Configure One-to-One, One-to-Many, and Many-to-Many relationships |
+
+## Prerequisites
+
+- .NET 10 SDK
+- PostgreSQL (or Docker)
+- Completed Module 01 (Getting Started)
+
+## What You'll Learn
+
+- Entity Framework Core fundamentals
+- Fluent API configuration patterns
+- Relationship modeling and navigation properties
+- Query optimization with Include/ThenInclude
+- Delete behaviors and cascade rules

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/Actor.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/Actor.cs
@@ -1,0 +1,36 @@
+namespace Movies.Api.Domain;
+
+public class Actor : EntityBase
+{
+    public string Name { get; private set; } = string.Empty;
+    public DateOnly BirthDate { get; private set; }
+    
+    // Navigation - many actors in many movies
+    public ICollection<Movie> Movies { get; private set; } = new List<Movie>();
+    
+    private Actor() { }
+    
+    private Actor(string name, DateOnly birthDate)
+    {
+        Name = name;
+        BirthDate = birthDate;
+    }
+    
+    public static Actor Create(string name, DateOnly birthDate)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Actor name cannot be empty.", nameof(name));
+            
+        return new Actor(name, birthDate);
+    }
+    
+    public void Update(string name, DateOnly birthDate)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Actor name cannot be empty.", nameof(name));
+            
+        Name = name;
+        BirthDate = birthDate;
+        UpdateLastModified();
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/Director.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/Director.cs
@@ -1,0 +1,43 @@
+namespace Movies.Api.Domain;
+
+public class Director : EntityBase
+{
+    public string Name { get; private set; } = string.Empty;
+    public string Country { get; private set; } = string.Empty;
+    public DateOnly BirthDate { get; private set; }
+    
+    // Navigation property - one director has many movies
+    public ICollection<Movie> Movies { get; private set; } = new List<Movie>();
+    
+    // Private constructor for EF Core
+    private Director() { }
+    
+    private Director(string name, string country, DateOnly birthDate)
+    {
+        Name = name;
+        Country = country;
+        BirthDate = birthDate;
+    }
+    
+    public static Director Create(string name, string country, DateOnly birthDate)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Director name cannot be empty.", nameof(name));
+            
+        if (birthDate > DateOnly.FromDateTime(DateTime.UtcNow))
+            throw new ArgumentException("Birth date cannot be in the future.", nameof(birthDate));
+            
+        return new Director(name, country, birthDate);
+    }
+    
+    public void Update(string name, string country, DateOnly birthDate)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Director name cannot be empty.", nameof(name));
+            
+        Name = name;
+        Country = country;
+        BirthDate = birthDate;
+        UpdateLastModified();
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/EntityBase.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/EntityBase.cs
@@ -1,0 +1,13 @@
+namespace Movies.Api.Domain;
+
+public abstract class EntityBase
+{
+    public Guid Id { get; protected set; } = Guid.NewGuid();
+    public DateTimeOffset CreatedAt { get; protected set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? LastModifiedAt { get; protected set; }
+
+    protected void UpdateLastModified()
+    {
+        LastModifiedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/Movie.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/Movie.cs
@@ -1,0 +1,62 @@
+namespace Movies.Api.Domain;
+
+public class Movie : EntityBase
+{
+    public string Title { get; private set; } = string.Empty;
+    public string Genre { get; private set; } = string.Empty;
+    public DateTimeOffset ReleaseDate { get; private set; }
+    public double Rating { get; private set; }
+    
+    // One-to-Many: Each movie has one director
+    public Guid DirectorId { get; private set; }
+    public Director Director { get; private set; } = null!;
+    
+    // One-to-One: Movie optionally has detailed info
+    public MovieDetail? Detail { get; private set; }
+    
+    // Many-to-Many: Movie has many actors
+    public ICollection<Actor> Actors { get; private set; } = new List<Actor>();
+
+    private Movie() { }
+
+    private Movie(string title, string genre, DateTimeOffset releaseDate, double rating)
+    {
+        Title = title;
+        Genre = genre;
+        ReleaseDate = releaseDate;
+        Rating = rating;
+    }
+
+    public static Movie Create(string title, string genre, DateTimeOffset releaseDate, double rating, Guid directorId)
+    {
+        ValidateInputs(title, genre, releaseDate, rating);
+        
+        if (directorId == Guid.Empty)
+            throw new ArgumentException("Director ID cannot be empty.", nameof(directorId));
+        
+        return new Movie(title, genre, releaseDate, rating) { DirectorId = directorId };
+    }
+
+    public void Update(string title, string genre, DateTimeOffset releaseDate, double rating)
+    {
+        ValidateInputs(title, genre, releaseDate, rating);
+
+        Title = title;
+        Genre = genre;
+        ReleaseDate = releaseDate;
+        Rating = rating;
+        UpdateLastModified();
+    }
+
+    private static void ValidateInputs(string title, string genre, DateTimeOffset releaseDate, double rating)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title cannot be empty.", nameof(title));
+        if (string.IsNullOrWhiteSpace(genre))
+            throw new ArgumentException("Genre cannot be empty.", nameof(genre));
+        if (releaseDate > DateTimeOffset.UtcNow.AddYears(5))
+            throw new ArgumentException("Release date cannot be more than 5 years in the future.", nameof(releaseDate));
+        if (rating < 0 || rating > 10)
+            throw new ArgumentOutOfRangeException(nameof(rating), "Rating must be between 0 and 10.");
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/MovieActor.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/MovieActor.cs
@@ -1,0 +1,19 @@
+namespace Movies.Api.Domain;
+
+/// <summary>
+/// Join entity for Many-to-Many relationship between Movies and Actors
+/// with additional payload data (Role, CharacterName, BillingOrder)
+/// </summary>
+public class MovieActor
+{
+    public Guid MovieId { get; set; }
+    public Movie Movie { get; set; } = null!;
+    
+    public Guid ActorId { get; set; }
+    public Actor Actor { get; set; } = null!;
+    
+    // Payload - extra data about the relationship
+    public string Role { get; set; } = string.Empty;  // "Lead", "Supporting", "Cameo"
+    public string CharacterName { get; set; } = string.Empty;
+    public int BillingOrder { get; set; }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/MovieDetail.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Domain/MovieDetail.cs
@@ -1,0 +1,47 @@
+namespace Movies.Api.Domain;
+
+public class MovieDetail : EntityBase
+{
+    public string Synopsis { get; private set; } = string.Empty;
+    public string TrailerUrl { get; private set; } = string.Empty;
+    public int RuntimeMinutes { get; private set; }
+    public string Language { get; private set; } = string.Empty;
+    
+    // Foreign key and navigation to Movie
+    public Guid MovieId { get; private set; }
+    public Movie Movie { get; private set; } = null!;
+    
+    private MovieDetail() { }
+    
+    private MovieDetail(Guid movieId, string synopsis, string trailerUrl, int runtimeMinutes, string language)
+    {
+        MovieId = movieId;
+        Synopsis = synopsis;
+        TrailerUrl = trailerUrl;
+        RuntimeMinutes = runtimeMinutes;
+        Language = language;
+    }
+    
+    public static MovieDetail Create(Guid movieId, string synopsis, string trailerUrl, int runtimeMinutes, string language)
+    {
+        if (movieId == Guid.Empty)
+            throw new ArgumentException("Movie ID cannot be empty.", nameof(movieId));
+            
+        if (runtimeMinutes <= 0)
+            throw new ArgumentException("Runtime must be positive.", nameof(runtimeMinutes));
+            
+        return new MovieDetail(movieId, synopsis, trailerUrl, runtimeMinutes, language);
+    }
+    
+    public void Update(string synopsis, string trailerUrl, int runtimeMinutes, string language)
+    {
+        if (runtimeMinutes <= 0)
+            throw new ArgumentException("Runtime must be positive.", nameof(runtimeMinutes));
+            
+        Synopsis = synopsis;
+        TrailerUrl = trailerUrl;
+        RuntimeMinutes = runtimeMinutes;
+        Language = language;
+        UpdateLastModified();
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Movies.Api.csproj
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Movies.Api.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/ActorConfiguration.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/ActorConfiguration.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Movies.Api.Domain;
+
+namespace Movies.Api.Persistence.Configurations;
+
+public class ActorConfiguration : IEntityTypeConfiguration<Actor>
+{
+    public void Configure(EntityTypeBuilder<Actor> builder)
+    {
+        builder.ToTable("Actors");
+        
+        builder.HasKey(a => a.Id);
+        
+        builder.Property(a => a.Name)
+            .IsRequired()
+            .HasMaxLength(150);
+            
+        // Configure Many-to-Many relationship with explicit join entity
+        // This allows storing additional data (Role, CharacterName, BillingOrder)
+        builder.HasMany(a => a.Movies)
+            .WithMany(m => m.Actors)
+            .UsingEntity<MovieActor>(
+                // Configure the Movie side of the relationship
+                l => l.HasOne(ma => ma.Movie)
+                      .WithMany()
+                      .HasForeignKey(ma => ma.MovieId),
+                // Configure the Actor side of the relationship
+                r => r.HasOne(ma => ma.Actor)
+                      .WithMany()
+                      .HasForeignKey(ma => ma.ActorId),
+                // Configure the join table itself
+                j =>
+                {
+                    j.ToTable("MovieActors");
+                    j.HasKey(ma => new { ma.MovieId, ma.ActorId });
+                    j.Property(ma => ma.Role).HasMaxLength(50);
+                    j.Property(ma => ma.CharacterName).HasMaxLength(200);
+                });
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/DirectorConfiguration.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/DirectorConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Movies.Api.Domain;
+
+namespace Movies.Api.Persistence.Configurations;
+
+public class DirectorConfiguration : IEntityTypeConfiguration<Director>
+{
+    public void Configure(EntityTypeBuilder<Director> builder)
+    {
+        builder.ToTable("Directors");
+        
+        builder.HasKey(d => d.Id);
+        
+        builder.Property(d => d.Name)
+            .IsRequired()
+            .HasMaxLength(150);
+            
+        builder.Property(d => d.Country)
+            .HasMaxLength(100);
+            
+        builder.Property(d => d.BirthDate)
+            .IsRequired();
+            
+        // Configure One-to-Many relationship
+        // One Director has many Movies
+        // Each Movie has one Director
+        builder.HasMany(d => d.Movies)
+            .WithOne(m => m.Director)
+            .HasForeignKey(m => m.DirectorId)
+            .OnDelete(DeleteBehavior.Restrict); // Prevent accidental cascade deletes
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/MovieConfiguration.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/MovieConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Movies.Api.Domain;
+
+namespace Movies.Api.Persistence.Configurations;
+
+public class MovieConfiguration : IEntityTypeConfiguration<Movie>
+{
+    public void Configure(EntityTypeBuilder<Movie> builder)
+    {
+        builder.ToTable("Movies");
+        
+        builder.HasKey(m => m.Id);
+        
+        builder.Property(m => m.Title)
+            .IsRequired()
+            .HasMaxLength(200);
+            
+        builder.Property(m => m.Genre)
+            .IsRequired()
+            .HasMaxLength(100);
+            
+        builder.Property(m => m.Rating)
+            .IsRequired();
+            
+        builder.Property(m => m.ReleaseDate)
+            .IsRequired();
+            
+        // DirectorId foreign key is configured in DirectorConfiguration
+        // One-to-One with MovieDetail is configured in MovieDetailConfiguration
+        // Many-to-Many with Actors is configured in ActorConfiguration
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/MovieDetailConfiguration.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/Configurations/MovieDetailConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Movies.Api.Domain;
+
+namespace Movies.Api.Persistence.Configurations;
+
+public class MovieDetailConfiguration : IEntityTypeConfiguration<MovieDetail>
+{
+    public void Configure(EntityTypeBuilder<MovieDetail> builder)
+    {
+        builder.ToTable("MovieDetails");
+        
+        builder.HasKey(d => d.Id);
+        
+        builder.Property(d => d.Synopsis)
+            .HasMaxLength(2000);
+            
+        builder.Property(d => d.TrailerUrl)
+            .HasMaxLength(500);
+            
+        builder.Property(d => d.Language)
+            .HasMaxLength(50);
+            
+        // Configure One-to-One relationship
+        // MovieDetail has one Movie
+        // Movie has one (optional) MovieDetail
+        builder.HasOne(d => d.Movie)
+            .WithOne(m => m.Detail)
+            .HasForeignKey<MovieDetail>(d => d.MovieId)
+            .OnDelete(DeleteBehavior.Cascade); // Delete movie -> delete its details
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/MovieDbContext.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Persistence/MovieDbContext.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Movies.Api.Domain;
+
+namespace Movies.Api.Persistence;
+
+public class MovieDbContext : DbContext
+{
+    public MovieDbContext(DbContextOptions<MovieDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Movie> Movies => Set<Movie>();
+    public DbSet<Director> Directors => Set<Director>();
+    public DbSet<Actor> Actors => Set<Actor>();
+    public DbSet<MovieDetail> MovieDetails => Set<MovieDetail>();
+    public DbSet<MovieActor> MovieActors => Set<MovieActor>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        // Apply all configurations from the current assembly
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(MovieDbContext).Assembly);
+    }
+}

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/Program.cs
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/Program.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore;
+using Movies.Api.Persistence;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services
+builder.Services.AddDbContext<MovieDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+// Example endpoint showing relationship queries
+app.MapGet("/movies", async (MovieDbContext context) =>
+{
+    var movies = await context.Movies
+        .Include(m => m.Director)
+        .Include(m => m.Actors)
+        .Include(m => m.Detail)
+        .Select(m => new
+        {
+            m.Id,
+            m.Title,
+            m.Genre,
+            m.Rating,
+            m.ReleaseDate,
+            Director = m.Director.Name,
+            Actors = m.Actors.Select(a => a.Name).ToList(),
+            HasDetail = m.Detail != null
+        })
+        .ToListAsync();
+    
+    return Results.Ok(movies);
+});
+
+app.MapGet("/directors/{id}/movies", async (Guid id, MovieDbContext context) =>
+{
+    var director = await context.Directors
+        .Include(d => d.Movies)
+        .FirstOrDefaultAsync(d => d.Id == id);
+    
+    if (director is null)
+        return Results.NotFound();
+    
+    return Results.Ok(new
+    {
+        director.Name,
+        Movies = director.Movies.Select(m => new { m.Id, m.Title, m.Rating })
+    });
+});
+
+app.Run();

--- a/modules/02-database-ef-core/efcore-relationships/Movies.Api/appsettings.json
+++ b/modules/02-database-ef-core/efcore-relationships/Movies.Api/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Database=movies_relationships;Username=postgres;Password=postgres"
+  }
+}

--- a/modules/02-database-ef-core/efcore-relationships/README.md
+++ b/modules/02-database-ef-core/efcore-relationships/README.md
@@ -1,0 +1,97 @@
+# EF Core Relationships
+
+This module demonstrates how to configure entity relationships in Entity Framework Core using Fluent API.
+
+📚 **Article**: [EF Core Relationships – Complete Configuration Guide](https://codewithmukesh.com/blog/efcore-relationships/)
+
+## Relationship Types Covered
+
+| Type | Entities | Description |
+|------|----------|-------------|
+| **One-to-Many** | Director → Movies | One director directs many movies |
+| **One-to-One** | Movie → MovieDetail | Each movie has optional detailed info |
+| **Many-to-Many** | Movies ↔ Actors | Movies have many actors, actors appear in many movies |
+
+## Key Files
+
+```
+Movies.Api/
+├── Domain/
+│   ├── EntityBase.cs         # Base entity with Id, timestamps
+│   ├── Director.cs           # Director entity (One-to-Many principal)
+│   ├── Movie.cs              # Movie entity (relationships configured)
+│   ├── MovieDetail.cs        # MovieDetail entity (One-to-One dependent)
+│   ├── Actor.cs              # Actor entity (Many-to-Many)
+│   └── MovieActor.cs         # Join entity with payload data
+├── Persistence/
+│   ├── MovieDbContext.cs     # DbContext with all DbSets
+│   └── Configurations/
+│       ├── DirectorConfiguration.cs    # One-to-Many config
+│       ├── MovieConfiguration.cs       # Movie properties
+│       ├── MovieDetailConfiguration.cs # One-to-One config
+│       └── ActorConfiguration.cs       # Many-to-Many with UsingEntity
+└── Program.cs                # Example queries with Include
+```
+
+## Running the Project
+
+```bash
+# Start PostgreSQL (if using Docker)
+docker run -d --name postgres -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres:17
+
+# Navigate to project
+cd Movies.Api
+
+# Create migration
+dotnet ef migrations add AddRelationships
+
+# Apply migration
+dotnet ef database update
+
+# Run the API
+dotnet run
+```
+
+## Relationship Configuration Highlights
+
+### One-to-Many (Director → Movies)
+```csharp
+builder.HasMany(d => d.Movies)
+    .WithOne(m => m.Director)
+    .HasForeignKey(m => m.DirectorId)
+    .OnDelete(DeleteBehavior.Restrict);
+```
+
+### One-to-One (Movie → MovieDetail)
+```csharp
+builder.HasOne(d => d.Movie)
+    .WithOne(m => m.Detail)
+    .HasForeignKey<MovieDetail>(d => d.MovieId)
+    .OnDelete(DeleteBehavior.Cascade);
+```
+
+### Many-to-Many with Payload (Movies ↔ Actors)
+```csharp
+builder.HasMany(a => a.Movies)
+    .WithMany(m => m.Actors)
+    .UsingEntity<MovieActor>(
+        l => l.HasOne(ma => ma.Movie).WithMany().HasForeignKey(ma => ma.MovieId),
+        r => r.HasOne(ma => ma.Actor).WithMany().HasForeignKey(ma => ma.ActorId),
+        j => {
+            j.ToTable("MovieActors");
+            j.HasKey(ma => new { ma.MovieId, ma.ActorId });
+        });
+```
+
+## Delete Behaviors
+
+| Behavior | Use When |
+|----------|----------|
+| **Restrict** | Prevent accidental deletes (Director with movies) |
+| **Cascade** | Delete dependents automatically (MovieDetail with Movie) |
+| **SetNull** | Orphan records allowed (nullable FK) |
+
+## Learn More
+
+- [EF Core Relationships Documentation](https://learn.microsoft.com/ef/core/modeling/relationships)
+- [Fluent API Configuration Guide](https://codewithmukesh.com/blog/fluent-api-entity-configuration-efcore/)


### PR DESCRIPTION
## Summary
Adds code samples for the EF Core Relationships article to Module 02.

## Changes
- Created `modules/02-database-ef-core/efcore-relationships/` with complete working example
- **Entities:** Director, Movie, MovieDetail, Actor, MovieActor (join entity)
- **Relationships demonstrated:**
  - One-to-Many: Director → Movies
  - One-to-One: Movie → MovieDetail
  - Many-to-Many with payload: Movies ↔ Actors
- Fluent API configurations with proper delete behaviors
- Example endpoints showing Include/projection queries

## Article
https://codewithmukesh.com/blog/efcore-relationships/

## Checklist
- [x] Code compiles
- [x] Follows existing project structure
- [x] README with instructions included
- [x] Course JSON updated to link article